### PR TITLE
fix bug when NOT filter around group(or|and|not)

### DIFF
--- a/ldap_filter/filter.py
+++ b/ldap_filter/filter.py
@@ -484,7 +484,7 @@ class ParserActions:
     @staticmethod
     def return_not_filter(input, start, end, filt=None, elements=None):
         for f in filt:
-            if isinstance(f, Filter):
+            if isinstance(f, (Filter, GroupAnd, GroupOr, GroupNot)):
                 return Filter.NOT(f)
 
 

--- a/tests/test_filter_parser.py
+++ b/tests/test_filter_parser.py
@@ -15,6 +15,15 @@ class TestFilterParser:
         string = parsed.to_string()
         assert string == filt
 
+    def test_negative_group_filter(self):
+        filt = "(!(|(cn=admins)))"
+        parsed = Filter.parse(filt)
+        assert parsed is not None
+        filt = '(&(!(|(sn=ron)(sn=bob)))(mail=*)(|(cn=john)(cn=alex)(cn=rob)))'
+        parsed = Filter.parse(filt)
+        string = parsed.to_string()
+        assert string == filt
+
     def test_allows_whitespace(self):
         filt = ' (&  (sn=smith with spaces)(one-two<=morespaces) (objectType=object Type) \n )  '
         parsed = Filter.parse(filt)


### PR DESCRIPTION
add group types in function  return_not_filter, because parse this string -   "(!(|(cn=admins)))"  returning None